### PR TITLE
[Feat/#27] TextField atom component 구현

### DIFF
--- a/ssh-web/src/components/atoms/TextField/TextField.styles.ts
+++ b/ssh-web/src/components/atoms/TextField/TextField.styles.ts
@@ -1,0 +1,49 @@
+// TextField.styles.ts
+import { tv } from 'tailwind-variants';
+
+export const textFieldStyles = tv({
+  base: 'p-2 font-medium w-64 relative', 
+  variants: {
+    variant: {
+      outlined: 'border-2 rounded-md ',
+      standard: 'border-b-2',
+    },
+    state: {
+      primary: 'border-blue-500',
+      secondary: 'border-gray-500',
+      danger: 'border-red-500',
+      unfocused: 'border-gray-300',
+    },
+    size: {
+      xs: 'text-xs p-1 w-40',
+      sm: 'text-sm p-1.5 w-48',
+      md: 'text-base p-2 w-56',
+      lg: 'text-lg p-2.5 w-64',
+      xl: 'text-xl p-3 w-72',
+    },
+  },
+  defaultVariants: {
+    variant: 'outlined',
+    state: 'secondary',
+    size: 'md', 
+  },
+});
+
+export const labelStyles = tv({
+  base: 'block font-medium mb-1 transition-all', 
+  variants: {
+    state: {
+      primary: 'text-blue-500',
+      secondary: 'text-gray-500',
+      danger: 'text-red-500',
+      unfocused: 'text-gray-300',
+    },
+    size: {
+      xs: 'text-xs',
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-lg',
+      xl: 'text-xl',
+    },
+  },
+});

--- a/ssh-web/src/components/atoms/TextField/TextField.styles.ts
+++ b/ssh-web/src/components/atoms/TextField/TextField.styles.ts
@@ -2,41 +2,46 @@
 import { tv } from 'tailwind-variants';
 
 export const textFieldStyles = tv({
-  base: 'p-2 font-medium w-64 relative', 
+  base: 'p-2 font-medium relative', 
   variants: {
     variant: {
       outlined: 'border-2 rounded-md ',
       standard: 'border-b-2',
     },
     state: {
-      primary: 'border-blue-500',
-      secondary: 'border-gray-500',
-      danger: 'border-red-500',
-      unfocused: 'border-gray-300',
+      primary: 'border-primary-500',
+      secondary: 'border-secondary-800',
+      danger: 'border-danger-500',
+      unfocused: 'border-secondary-400',
     },
     size: {
-      xs: 'text-xs p-1 w-40',
-      sm: 'text-sm p-1.5 w-48',
-      md: 'text-base p-2 w-56',
-      lg: 'text-lg p-2.5 w-64',
-      xl: 'text-xl p-3 w-72',
+      xs: 'text-xs p-1',
+      sm: 'text-sm p-1.5',
+      md: 'text-base p-2',
+      lg: 'text-lg p-2.5',
+      xl: 'text-xl p-3',
+    },
+    fullWidth: {
+      true: 'w-full',   
+    },
+    disabled: {
+      true: 'bg-secondary-200 text-secondary-600 cursor-not-allowed rounded',
     },
   },
   defaultVariants: {
     variant: 'outlined',
-    state: 'secondary',
     size: 'md', 
   },
 });
-
+ 
 export const labelStyles = tv({
   base: 'block font-medium mb-1 transition-all', 
   variants: {
     state: {
-      primary: 'text-blue-500',
-      secondary: 'text-gray-500',
-      danger: 'text-red-500',
-      unfocused: 'text-gray-300',
+      primary: 'text-primary-500',
+      secondary: 'text-secondary-800',
+      danger: 'text-danger-500',
+      unfocused : 'text-secondary-600',
     },
     size: {
       xs: 'text-xs',

--- a/ssh-web/src/components/atoms/TextField/TextField.types.ts
+++ b/ssh-web/src/components/atoms/TextField/TextField.types.ts
@@ -1,0 +1,13 @@
+export type TVariant = 'outlined' | 'standard';
+export type TState = 'primary' | 'secondary' | 'danger' | 'unfocused';
+export type TSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
+export interface TextFieldProps {
+  variant?: TVariant;
+  state?: TState;
+  size?: TSize;
+  label?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  classNameStyles?: string;
+}

--- a/ssh-web/src/components/atoms/TextField/TextField.types.ts
+++ b/ssh-web/src/components/atoms/TextField/TextField.types.ts
@@ -9,5 +9,7 @@ export interface TextFieldProps {
   label?: string;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  disabled?: boolean;
+  fullWidth?: boolean;
   classNameStyles?: string;
 }

--- a/ssh-web/src/components/atoms/TextField/index.stories.tsx
+++ b/ssh-web/src/components/atoms/TextField/index.stories.tsx
@@ -50,7 +50,6 @@ const StateList: TState[] = [
   'primary',
   'secondary',
   'danger',
-  'unfocused',
 ];
 
 // Outlined 스토리
@@ -63,7 +62,7 @@ export const Outlined: Story = {
   render: (args) => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
       {StateList.map((state) => (
-        <TextField {...args} key={state} state={state} variant="outlined" />
+        <TextField {...args}  key={state} state={state} variant="outlined" />
       ))}
     </div>
   ),
@@ -79,7 +78,7 @@ export const Standard: Story = {
   render: (args) => (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
       {StateList.map((state) => (
-        <TextField {...args} key={state} state={state} variant="standard" />
+          <TextField {...args} key={state} state={state} variant="standard" />
       ))}
     </div>
   ),

--- a/ssh-web/src/components/atoms/TextField/index.stories.tsx
+++ b/ssh-web/src/components/atoms/TextField/index.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import TextField from './index';
+import { TState } from './TextField.types';
+
+const meta = {
+  title: 'UI/Atoms/TextField',
+  component: TextField,
+  parameters: {
+    controls: {
+      expanded : true
+    }
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    label: {
+      description: '표시할 placeholder 및 label',
+      control: 'text',
+    },
+    state: {
+      description: '색상',
+    },
+    size: {
+      description: 'TextField의 전체적인 크기',
+      control: { type: 'select', options: ['xs', 'sm', 'md', 'lg', 'xl'] }, // 드롭다운 선택 가능
+    },
+    value: {
+      description: '입력값',
+      control: 'text', 
+    },
+    variant: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+} satisfies Meta<typeof TextField>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const StateList: TState[] = [
+  'primary',
+  'secondary',
+  'danger',
+  'unfocused',
+];
+
+// Outlined 스토리
+export const Outlined: Story = {
+  args: {
+    label: '라벨',
+    value: '',
+    size: 'md',
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {StateList.map((state) => (
+        <TextField {...args} key={state} state={state} variant="outlined" />
+      ))}
+    </div>
+  ),
+};
+
+// Standard 스토리
+export const Standard: Story = {
+  args: {
+    label: '라벨',
+    value: '',
+    size: 'md',
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {StateList.map((state) => (
+        <TextField {...args} key={state} state={state} variant="standard" />
+      ))}
+    </div>
+  ),
+};

--- a/ssh-web/src/components/atoms/TextField/index.tsx
+++ b/ssh-web/src/components/atoms/TextField/index.tsx
@@ -1,27 +1,89 @@
-import React from 'react';
-import { TextFieldProps } from './TextField.types';
-import { textFieldStyles,labelStyles } from './TextField.styles';
+import React, { useState } from 'react';
+import { TSize, TextFieldProps } from './TextField.types';
+import { textFieldStyles, labelStyles } from './TextField.styles';
 
-const TextField: React.FC<TextFieldProps> = ({ variant, state, size, label, value, onChange, classNameStyles, }) => {
-  const inputClassName = textFieldStyles({ variant, state, size });
-  const labelClassName = labelStyles({ state, size});
+// size에 따른 위치 조정 함수
+const getTranslateValue = (size: TSize, isFloating: boolean) => {
+  switch (size) {
+    case 'xs':
+      return isFloating ? '-translate-y-2' : 'translate-y-3';
+    case 'sm':
+      return isFloating ? '-translate-y-3' : 'translate-y-3';
+    case 'md':
+      return isFloating ? '-translate-y-3' : 'translate-y-3';
+    case 'lg':
+      return isFloating ? '-translate-y-3' : 'translate-y-3';
+    case 'xl':
+      return isFloating ? '-translate-y-4' : 'translate-y-3';
+  }
+};
+  
+
+const TextField: React.FC<TextFieldProps> = ({
+  variant,
+  state,
+  size ='md',
+  label,
+  value,
+  onChange,
+  disabled = false,
+  fullWidth = false,
+  classNameStyles,
+}) => {
+
+  const [focused, setFocused] = useState(false);
+  const isFloating = focused || value !== '';
+
+  const inputClassName = textFieldStyles({
+    variant,
+    state: isFloating ? state : 'unfocused',
+    size,
+    fullWidth,
+    disabled
+  });
+   const labelClassName = labelStyles({ 
+    state: isFloating ? state : 'unfocused', 
+    size,
+   });
+
+  const handleFocus = () => setFocused(true);
+  const handleBlur = () => setFocused(false);
+
+  const translateValue = getTranslateValue(size, isFloating);
 
   return (
-    <div className="mb-4">
-      { state !== 'unfocused' && 
-        <label className={labelClassName}>
-          {label}
-        </label>
-      }
-        <input
-          type="text"
-          className={`bg-transparent outline-none text-black
-          ${inputClassName} 
-          ${classNameStyles}`}
-          value={value}
-          onChange={onChange}
-          placeholder={label}
-        />
+    <div className={`relative mb-4 ${fullWidth ? 'w-full' : ''}`}>
+      <label
+        className={`
+          ${labelClassName}
+          absolute 
+          left-2 
+          transition-all 
+          duration-200
+          transform 
+          scale-90
+          ${translateValue}
+          ${variant === 'outlined' && isFloating ? 'bg-white px-1 z-20' : ''}
+          `}
+      >
+        {label}
+      </label>
+      <input
+        type="text"
+        className={`bg-transparent outline-none text-black  
+          ${inputClassName}
+          ${classNameStyles} 
+        ${
+          variant === 'outlined' ? 'pt-4 pb-2 border-2 rounded' : 'pt-2 pb-1'
+          } 
+        ${isFloating ? '' : 'border-secondary-400'}
+        `}
+        value={value}
+        onChange={onChange}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        disabled={disabled} 
+      />
     </div>
   );
 };

--- a/ssh-web/src/components/atoms/TextField/index.tsx
+++ b/ssh-web/src/components/atoms/TextField/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TextFieldProps } from './TextField.types';
+import { textFieldStyles,labelStyles } from './TextField.styles';
+
+const TextField: React.FC<TextFieldProps> = ({ variant, state, size, label, value, onChange, classNameStyles, }) => {
+  const inputClassName = textFieldStyles({ variant, state, size });
+  const labelClassName = labelStyles({ state, size});
+
+  return (
+    <div className="mb-4">
+      { state !== 'unfocused' && 
+        <label className={labelClassName}>
+          {label}
+        </label>
+      }
+        <input
+          type="text"
+          className={`bg-transparent outline-none text-black
+          ${inputClassName} 
+          ${classNameStyles}`}
+          value={value}
+          onChange={onChange}
+          placeholder={label}
+        />
+    </div>
+  );
+};
+
+export default TextField;


### PR DESCRIPTION
## 🥥 Contents

<!--
-   작업한 사항들에 대한 상세 설명
-   필요할 경우 관련 코드 기입
-->

TextField
- 크기 설정과 상태에 따른 색상 설정 가능
- Outline과 Standard 두 종류 


## 📸 Screenshot

<!--
-   구현된 기능들 촬영
-   필수 사항 x
-->

**Outlined**
![Outlined](https://github.com/user-attachments/assets/054c159c-ae25-45c8-acb8-71382cb6dedf)



**Standard**
![Standard](https://github.com/user-attachments/assets/908c7aed-de5f-462f-8d6e-cabbc2a7655b)

ps)
 1. nav와 top-bar에 z-index 30 부여하는것을 고려하여 focus 되었을때  label에는 z-index를 20을 부여하였습니다.
 2. disabled 되었을때 label이 없어지는데, 이를 아직 해결하지 못했습니다. 좋은 의견 부탁드려요.
 3. unfoused 되었을때 secondary Textfield에 style이 적용되지 않는것을 해결했습니다. 
 4. color가 아니라 state로 두었는데, 이는 color보다는 textfield의 상태에 중점을 두고싶어서 state라고 했습니다. 다른 의견 있으면 적극 코멘트 바랍니다. 

## ⚓ Related Issue

<!--
-   PR 에 관련된 이슈들 등록
-   #이슈번호
-   만약 해당 이슈들을 닫을 수 있다면 -> close #이슈번호
-->

- #27 
## 📚 Reference

<!--
-   PR 작업 중 참고한 자료, 문서들 기입
-->
