### PR TITLE
[Feat/#34] Badge Atom 컴포넌트 구현

### DIFF
--- a/ssh-web/src/components/atoms/Badge/Badge.stories.tsx
+++ b/ssh-web/src/components/atoms/Badge/Badge.stories.tsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Badge } from './index';
+import { TColor } from '../../../themes/themeBase';
+import { HiOutlineCheckCircle } from 'react-icons/hi';
+
+const meta: Meta<typeof Badge> = {
+  title: 'UI/Atoms/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1rem' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    text: {
+      description: '뱃지 내부에 표시될 텍스트',
+      control: 'text',
+    },
+    color: {
+      description: '뱃지의 배경 색상',
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'danger', 'warning', 'dark', 'light'],
+      },
+    },
+    textColor: {
+      description: '텍스트의 색상',
+      control: {
+        type: 'select',
+        options: ['primary', 'secondary', 'danger', 'warning', 'dark', 'light'],
+      },
+    },
+    size: {
+      description: '뱃지와 텍스트의 크기',
+      control: {
+        type: 'select',
+        options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      },
+    },
+    weight: {
+      description: '텍스트의 font-weight',
+      control: {
+        type: 'select',
+        options: ['light', 'regular', 'medium', 'semibold', 'bold'],
+      },
+    },
+    startIcon: {
+      description: '텍스트 앞에 추가할 아이콘 또는 콘텐츠',
+      control: false,
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Badge>;
+
+export const Primary: Story = {
+  args: {
+    text: '기본 뱃지',
+    color: 'primary',
+    textColor: 'light',
+    size: 'md',
+    weight: 'light',
+    startIcon: <HiOutlineCheckCircle />,
+  },
+};
+
+export const WithCustomColors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      <Badge
+        text="Primary Badge"
+        color="primary"
+        textColor="light"
+        size="md"
+        weight="regular"
+      />
+      <Badge
+        text="Secondary Badge"
+        color="secondary"
+        textColor="dark"
+        size="md"
+        weight="regular"
+      />
+      <Badge
+        text="Warning Badge"
+        color="warning"
+        textColor="dark"
+        size="md"
+        weight="regular"
+      />
+    </div>
+  ),
+};
+
+const colorList: TColor[] = [
+  'primary',
+  'secondary',
+  'danger',
+  'warning',
+  'dark',
+  'light',
+];
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {colorList.map((color) => (
+        <Badge
+          key={color}
+          color={color}
+          text="Badge"
+          textColor="light"
+          size="md"
+          weight="light"
+        />
+      ))}
+    </div>
+  ),
+};
+
+const sizeList: ('xs' | 'sm' | 'md' | 'lg' | 'xl')[] = [
+  'xs',
+  'sm',
+  'md',
+  'lg',
+  'xl',
+];
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {sizeList.map((size) => (
+        <Badge
+          key={size}
+          size={size}
+          text="Badge"
+          color="primary"
+          textColor="light"
+          weight="light"
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const Weights: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      {['light', 'regular', 'medium', 'semibold', 'bold'].map((weight) => (
+        <Badge
+          key={weight}
+          size="md"
+          text={weight.charAt(0).toUpperCase() + weight.slice(1)}
+          color="primary"
+          textColor="light"
+          weight={
+            weight as 'light' | 'regular' | 'medium' | 'semibold' | 'bold'
+          }
+        />
+      ))}
+    </div>
+  ),
+};
+
+export const WithStartIcon: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '1rem' }}>
+      <Badge
+        text="With Icon"
+        color="primary"
+        textColor="light"
+        size="md"
+        weight="regular"
+        startIcon={<HiOutlineCheckCircle />}
+      />
+      <Badge
+        text="With Image"
+        color="secondary"
+        textColor="dark"
+        size="md"
+        weight="regular"
+        startIcon={
+          <img
+            src="https://via.placeholder.com/18"
+            alt="예시 이미지"
+            className="rounded-full"
+          />
+        }
+      />
+    </div>
+  ),
+};

--- a/ssh-web/src/components/atoms/Badge/Badge.styles.ts
+++ b/ssh-web/src/components/atoms/Badge/Badge.styles.ts
@@ -1,0 +1,53 @@
+import { tv } from 'tailwind-variants';
+
+const backgroundVariants = {
+  primary: 'bg-primary-500 hover:bg-primary-400 active:bg-primary-700',
+  secondary: 'bg-secondary-500 hover:bg-secondary-400 active:bg-secondary-700',
+  danger: 'bg-red-500 hover:bg-red-400 active:bg-red-700',
+  warning: 'bg-yellow-500 hover:bg-yellow-400 active:bg-yellow-700',
+  dark: 'bg-black hover:bg-gray-800 active:bg-gray-900',
+  light: 'bg-white hover:bg-gray-100 active:bg-gray-200',
+};
+
+const textVariants = {
+  primary: 'text-primary-500',
+  secondary: 'text-secondary-500',
+  danger: 'text-red-500',
+  warning: 'text-yellow-500',
+  dark: 'text-black',
+  light: 'text-white',
+};
+
+export const badgeStyles = tv({
+  base: 'inline-flex items-center justify-center rounded-full px-2 py-1 h-max transition-colors duration-300 ease-in-out cursor-default',
+  variants: {
+    color: {
+      primary: backgroundVariants.primary,
+      secondary: backgroundVariants.secondary,
+      danger: backgroundVariants.danger,
+      warning: backgroundVariants.warning,
+      dark: backgroundVariants.dark,
+      light: backgroundVariants.light,
+    },
+    textColor: {
+      primary: textVariants.primary,
+      secondary: textVariants.secondary,
+      danger: textVariants.danger,
+      warning: textVariants.warning,
+      dark: textVariants.dark,
+      light: textVariants.light,
+    },
+    size: {
+      xs: 'text-xs px-2 py-1',
+      sm: 'text-sm px-3 py-1',
+      md: 'text-base px-4 py-1.5',
+      lg: 'text-lg px-5 py-2',
+      xl: 'text-xl px-6 py-2.5',
+    },
+  },
+  defaultVariants: {
+    size: 'md',
+    color: 'primary',
+    textColor: 'light',
+  },
+});

--- a/ssh-web/src/components/atoms/Badge/Badge.types.ts
+++ b/ssh-web/src/components/atoms/Badge/Badge.types.ts
@@ -1,0 +1,12 @@
+import { TColor } from '../../../themes/themeBase';
+import { ReactNode } from 'react';
+
+export interface BadgeProps {
+  text: string;
+  color?: TColor;
+  textColor?: TColor;
+  size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  weight?: 'light' | 'regular' | 'medium' | 'semibold' | 'bold';
+  startIcon?: ReactNode;
+  classNameStyles?: string;
+}

--- a/ssh-web/src/components/atoms/Badge/Badge.types.ts
+++ b/ssh-web/src/components/atoms/Badge/Badge.types.ts
@@ -1,7 +1,7 @@
 import { TColor } from '../../../themes/themeBase';
 import { ReactNode } from 'react';
 
-export interface BadgeProps {
+export interface IBadgeProps {
   text: string;
   color?: TColor;
   textColor?: TColor;

--- a/ssh-web/src/components/atoms/Badge/index.tsx
+++ b/ssh-web/src/components/atoms/Badge/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BadgeProps } from './Badge.types';
+import { IBadgeProps } from './Badge.types';
 import { badgeStyles } from './Badge.styles';
 import { Typography } from '../Typography';
 
@@ -11,7 +11,7 @@ export const Badge = ({
   weight = 'light',
   startIcon,
   classNameStyles,
-}: BadgeProps) => {
+}: IBadgeProps) => {
   const className = badgeStyles({ color, textColor, size });
 
   return (

--- a/ssh-web/src/components/atoms/Badge/index.tsx
+++ b/ssh-web/src/components/atoms/Badge/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { BadgeProps } from './Badge.types';
+import { badgeStyles } from './Badge.styles';
+import { Typography } from '../Typography';
+
+export const Badge = ({
+  text,
+  color = 'primary',
+  textColor = 'light',
+  size = 'md',
+  weight = 'light',
+  startIcon,
+  classNameStyles,
+}: BadgeProps) => {
+  const className = badgeStyles({ color, textColor, size });
+
+  return (
+    <div className={`${className} ${classNameStyles}`}>
+      {startIcon && <span className="mr-1">{startIcon}</span>}
+      <Typography size={size} color={textColor} weight={weight}>
+        {text}
+      </Typography>
+    </div>
+  );
+};


### PR DESCRIPTION
## 안내
아이콘, 이미지는 사용 시 다양한 케이스를 고려해서, child로 받도록 했고,
1. 이미지의 경우 사용측에서 직접 크기를 지정해서 사용하도록 했습니다.
2. 아이콘은 따로 크기지정 안할 시, 뱃지의 텍스트사이즈를 따라갑니다.

## 🥥 Contents
1. 타이포그래피 아톰을 사용
2. 아이콘, 이미지를 함께 사용할 수 있는 startIcon (children)속성
4. 폰트컬러, weight, 배경 색 등 따로 커스텀 가능하도록 구현

<!--
-   작업한 사항들에 대한 상세 설명
-   필요할 경우 관련 코드 기입
-->

## 📸 Screenshot
![Badge](https://github.com/user-attachments/assets/dbfdfc15-86e1-4489-be21-dd2c03bf5a9c)

<!--
-   구현된 기능들 촬영
-   필수 사항 x
-->

## ⚓ Related Issue
- #34 
<!--
-   PR 에 관련된 이슈들 등록
-   #이슈번호
-   만약 해당 이슈들을 닫을 수 있다면 -> close #이슈번호
-->

## 📚 Reference

<!--
-   PR 작업 중 참고한 자료, 문서들 기입
-->
