### PR TITLE
[Feat/#50] 사용자 도메인 api 연결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: SolSolHigh-FE Deploy
 
 on:
     push:
-        branches: feat/#50-user-api
+        branches: develop
 
 jobs:
     deploy:
@@ -17,4 +17,4 @@ jobs:
                   password: ${{ secrets.SSH_PASSWORD }}
                   script: |
                       cd ~/solsol-high
-                      ./static.sh feat/#50-user-api
+                      ./static.sh develop

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: SolSolHigh-FE Deploy
 
 on:
     push:
-        branches: develop
+        branches: feat/#50-user-api
 
 jobs:
     deploy:
@@ -17,4 +17,4 @@ jobs:
                   password: ${{ secrets.SSH_PASSWORD }}
                   script: |
                       cd ~/solsol-high
-                      ./static.sh
+                      ./static.sh feat/#50-user-api

--- a/ssh-web/src/App.tsx
+++ b/ssh-web/src/App.tsx
@@ -31,10 +31,11 @@ function App() {
         location.pathname === '/signup' ||
         location.pathname === '/mypage' ||
         location.pathname === '/manage' ||
-        location.pathname === '/quiz/solve'
+        location.pathname === '/quiz/solve' ||
+        location.pathname === '/request'
       ) && <NavigationBar />}
       <div
-        className={`${size === 'M' || size === 'T' ? (location.pathname === '/login' || location.pathname === '/signup' || location.pathname === '/mypage' || location.pathname === '/manage' ? '!min-h-full' : 'pb-[4rem]') : 'pb-0'} BODY-LAYOUT h-[calc(100%-3.5rem)] desktop:flex-1 relative w-full flex justify-center`}
+        className={`${size === 'M' || size === 'T' ? (location.pathname === '/login' || location.pathname === '/signup' || location.pathname === '/mypage' || location.pathname === '/manage' || location.pathname === '/quiz/solve' || location.pathname === '/request' ? '!min-h-full' : 'pb-[4rem]') : 'pb-0'} BODY-LAYOUT h-[calc(100%-3.5rem)] desktop:flex-1 relative w-full flex justify-center`}
       >
         <Outlet />
       </div>

--- a/ssh-web/src/apis/interceptors.ts
+++ b/ssh-web/src/apis/interceptors.ts
@@ -1,9 +1,8 @@
 import axios from 'axios';
 import { showToast } from '../utils/toastUtil';
-import { checkSession } from './userApi';
 
 export const api = axios.create({
-  baseURL: 'http://localhost:8080',
+  baseURL: 'https://www.solsol-high.kro.kr',
   headers: {
     'Content-Type': 'application/json',
   },
@@ -12,7 +11,6 @@ export const api = axios.create({
 
 api.interceptors.request.use(
   async (config) => {
-    await checkSession();
     return config;
   },
   (error) => {

--- a/ssh-web/src/apis/interceptors.ts
+++ b/ssh-web/src/apis/interceptors.ts
@@ -3,7 +3,7 @@ import { showToast } from '../utils/toastUtil';
 import { checkSession } from './userApi';
 
 export const api = axios.create({
-  baseURL: 'https://www.solsol-high.kro.kr',
+  baseURL: 'http://localhost:8080',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/ssh-web/src/apis/interceptors.ts
+++ b/ssh-web/src/apis/interceptors.ts
@@ -2,7 +2,10 @@ import axios from 'axios';
 import { showToast } from '../utils/toastUtil';
 
 export const api = axios.create({
-  baseURL: 'https://www.solsol-high.kro.kr',
+  baseURL:
+    process.env.NODE_ENV === 'development'
+      ? ''
+      : 'https://www.solsol-high.kro.kr',
   headers: {
     'Content-Type': 'application/json',
   },

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -29,3 +29,15 @@ export const getMyChildren = () => {
 export const getMyParents = () => {
   return api.get<IParent>('/api/children/parents');
 };
+
+export const getMyWaitingChildren = () => {
+  return api.get<IChild[]>('/api/parents/children/waiting');
+};
+
+export const deleteMyChild = (nickname: string) => {
+  return api.patch('/api/parents/children', { nickname: nickname });
+};
+
+export const deleteMyWaitingChild = (nickname: string) => {
+  return api.patch('/api/parents/children/waiting', { nickname: nickname });
+};

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -1,4 +1,9 @@
-import { IChild, ISignupRequest, IUserInfo } from '../interfaces/userInterface';
+import {
+  IChild,
+  IParent,
+  ISignupRequest,
+  IUserInfo,
+} from '../interfaces/userInterface';
 import { api } from './interceptors';
 
 export const checkSession = async () => {
@@ -19,4 +24,8 @@ export const getUserInfo = () => {
 
 export const getMyChildren = () => {
   return api.get<IChild[]>('/api/parents/childrens');
+};
+
+export const getMyParents = () => {
+  return api.get<IParent>('/api/children/parents');
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -23,7 +23,7 @@ export const getUserInfo = () => {
 };
 
 export const getMyChildren = () => {
-  return api.get<IChild[]>('/api/parents/childrens');
+  return api.get<IChild[]>('/api/parents/children');
 };
 
 export const getMyParents = () => {

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -34,6 +34,10 @@ export const getMyWaitingChildren = () => {
   return api.get<IChild[]>('/api/parents/children/waiting');
 };
 
+export const getMyWaitingParent = () => {
+  return api.get<IParent>('/api/children/parents/waiting');
+};
+
 export const deleteMyChild = (nickname: string) => {
   return api.patch('/api/parents/children', { nickname: nickname });
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -1,5 +1,10 @@
+import { ISignupRequest } from '../interfaces/userInterface';
 import { api } from './interceptors';
 
 export const checkSession = async () => {
   return await api.options('/api/users/info');
+};
+
+export const signup = async (signupRequest: ISignupRequest) => {
+  return await api.post('/api/users', { data: signupRequest });
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -1,10 +1,22 @@
-import { ISignupRequest } from '../interfaces/userInterface';
+import { IChild, ISignupRequest, IUserInfo } from '../interfaces/userInterface';
 import { api } from './interceptors';
 
 export const checkSession = async () => {
   return await api.options('/api/users/info');
 };
 
+export const nicknameDuplicate = (nickname: string) => {
+  return api.get(`/api/users?nickname=${nickname}`);
+};
+
 export const signup = (signupRequest: ISignupRequest) => {
   return api.post('/api/users', signupRequest);
+};
+
+export const getUserInfo = () => {
+  return api.get<IUserInfo>('/api/users/info');
+};
+
+export const getMyChildren = () => {
+  return api.get<IChild[]>('/api/parents/children');
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -41,3 +41,11 @@ export const deleteMyChild = (nickname: string) => {
 export const deleteMyWaitingChild = (nickname: string) => {
   return api.patch('/api/parents/children/waiting', { nickname: nickname });
 };
+
+export const findChildByNickname = (nickname: string) => {
+  return api.post('/api/children', { nickname: nickname });
+};
+
+export const requestChild = (nickname: string) => {
+  return api.post('/api/parents/children/request', { nickname: nickname });
+};

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -18,5 +18,5 @@ export const getUserInfo = () => {
 };
 
 export const getMyChildren = () => {
-  return api.get<IChild[]>('/api/parents/children');
+  return api.get<IChild[]>('/api/parents/childrens');
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -5,6 +5,6 @@ export const checkSession = async () => {
   return await api.options('/api/users/info');
 };
 
-export const signup = async (signupRequest: ISignupRequest) => {
-  return await api.post('/api/users', { data: signupRequest });
+export const signup = (signupRequest: ISignupRequest) => {
+  return api.post('/api/users', { data: signupRequest });
 };

--- a/ssh-web/src/apis/userApi.ts
+++ b/ssh-web/src/apis/userApi.ts
@@ -6,5 +6,5 @@ export const checkSession = async () => {
 };
 
 export const signup = (signupRequest: ISignupRequest) => {
-  return api.post('/api/users', { data: signupRequest });
+  return api.post('/api/users', signupRequest);
 };

--- a/ssh-web/src/components/molecules/InfoList/index.tsx
+++ b/ssh-web/src/components/molecules/InfoList/index.tsx
@@ -91,10 +91,10 @@ export const InfoList = ({
             >
               <Typography color="dark" weight="semibold" size="sm">
                 {mascotType === 'PARENT'
-                  ? '아직 연결해주신 부모님이 없어요!'
-                  : '아직 연결된 자녀가 없어요!'}
+                  ? '아직 연결된 자녀가 없어요!'
+                  : '아직 연결해주신 부모님이 없어요!'}
               </Typography>
-              {mascotType === 'CHILD' && (
+              {mascotType === 'PARENT' && (
                 <Button size="sm">자녀 초대하기</Button>
               )}
             </div>

--- a/ssh-web/src/components/molecules/InfoList/index.tsx
+++ b/ssh-web/src/components/molecules/InfoList/index.tsx
@@ -16,6 +16,7 @@ import {
   mascotStyles,
   titleStyles,
 } from './InfoList.styles';
+import { useNavigate } from 'react-router-dom';
 
 export const InfoList = ({
   type,
@@ -27,6 +28,8 @@ export const InfoList = ({
   children,
   classNameStyles,
 }: InfoListProps) => {
+  const nav = useNavigate();
+
   return (
     <div className={`${containerStyles()} ${classNameStyles}`}>
       {/* 타이틀 */}
@@ -36,7 +39,7 @@ export const InfoList = ({
         </Typography>
         {hasMore && (
           <Icon color="dark" size="sm">
-            <HiChevronRight />
+            <HiChevronRight onClick={() => nav('/manage')} />
           </Icon>
         )}
       </div>

--- a/ssh-web/src/components/molecules/InfoList/index.tsx
+++ b/ssh-web/src/components/molecules/InfoList/index.tsx
@@ -39,7 +39,9 @@ export const InfoList = ({
         </Typography>
         {hasMore && (
           <Icon color="dark" size="sm">
-            <HiChevronRight onClick={() => nav('/manage')} />
+            <HiChevronRight
+              onClick={() => nav('/manage', { state: { type: mascotType } })}
+            />
           </Icon>
         )}
       </div>

--- a/ssh-web/src/components/molecules/InfoList/index.tsx
+++ b/ssh-web/src/components/molecules/InfoList/index.tsx
@@ -90,9 +90,13 @@ export const InfoList = ({
               })}
             >
               <Typography color="dark" weight="semibold" size="sm">
-                아직 초대된 {mascotType}가 없어요!!
+                {mascotType === 'PARENT'
+                  ? '아직 연결해주신 부모님이 없어요!'
+                  : '아직 연결된 자녀가 없어요!'}
               </Typography>
-              <Button size="sm">{mascotType} 초대하기</Button>
+              {mascotType === 'CHILD' && (
+                <Button size="sm">자녀 초대하기</Button>
+              )}
             </div>
           )}
         </div>

--- a/ssh-web/src/components/molecules/LoginNav/index.tsx
+++ b/ssh-web/src/components/molecules/LoginNav/index.tsx
@@ -3,6 +3,7 @@ import { LoginNavProps } from './LoginNav.types';
 import { loginNavStyles } from './LoginNav.styles';
 
 export const LoginNav = ({ children, classNameStyles }: LoginNavProps) => {
+  console.log('it"s for test');
   return (
     <div className={`${loginNavStyles()} ${classNameStyles}`}>
       <a href="https://www.solsol-high.kro.kr/api/oauth2/authorization/naver">

--- a/ssh-web/src/components/molecules/LoginNav/index.tsx
+++ b/ssh-web/src/components/molecules/LoginNav/index.tsx
@@ -3,7 +3,6 @@ import { LoginNavProps } from './LoginNav.types';
 import { loginNavStyles } from './LoginNav.styles';
 
 export const LoginNav = ({ children, classNameStyles }: LoginNavProps) => {
-  console.log('it"s for test');
   return (
     <div className={`${loginNavStyles()} ${classNameStyles}`}>
       <a href="https://www.solsol-high.kro.kr/api/oauth2/authorization/naver">

--- a/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
+++ b/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
@@ -3,6 +3,7 @@ import { IChild } from '../../../interfaces/userInterface';
 
 export interface MascotCardProps extends React.ComponentProps<'div'> {
   childInfo: IChild;
+  isWaiting: boolean;
   children?: ReactNode;
   classNameStyles?: string;
 }

--- a/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
+++ b/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
@@ -1,8 +1,9 @@
 import { ReactNode } from 'react';
-import { IChild } from '../../../interfaces/userInterface';
+import { IChild, IParent } from '../../../interfaces/userInterface';
 
 export interface MascotCardProps extends React.ComponentProps<'div'> {
-  childInfo: IChild;
+  info: IChild | IParent;
+  type: 'PARENT' | 'CHILD';
   isWaiting?: boolean;
   withTrash?: boolean;
   children?: ReactNode;

--- a/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
+++ b/ssh-web/src/components/molecules/MascotCard/MascotCard.types.ts
@@ -3,7 +3,8 @@ import { IChild } from '../../../interfaces/userInterface';
 
 export interface MascotCardProps extends React.ComponentProps<'div'> {
   childInfo: IChild;
-  isWaiting: boolean;
+  isWaiting?: boolean;
+  withTrash?: boolean;
   children?: ReactNode;
   classNameStyles?: string;
 }

--- a/ssh-web/src/components/molecules/MascotCard/index.tsx
+++ b/ssh-web/src/components/molecules/MascotCard/index.tsx
@@ -10,7 +10,8 @@ import { deleteMyChild, deleteMyWaitingChild } from '../../../apis/userApi';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const MascotCard = ({
-  childInfo,
+  info,
+  type,
   isWaiting = false,
   withTrash = true,
   children,
@@ -19,12 +20,14 @@ export const MascotCard = ({
   const queryClient = useQueryClient();
   const { mutate } = useMutation({
     mutationFn: async (nickname: string) =>
-      !isWaiting
+      type === 'CHILD' && !isWaiting
         ? await deleteMyChild(nickname)
         : await deleteMyWaitingChild(nickname),
     onSuccess: (res) => {
       alert(res.data.description);
-      queryClient.invalidateQueries({ queryKey: ['children', 'waiting'] });
+      queryClient.invalidateQueries({
+        queryKey: ['children', 'waiting'],
+      });
     },
     onError: (err) => alert(err.message),
   });
@@ -32,33 +35,33 @@ export const MascotCard = ({
   return (
     <div className="relative flex items-center w-full p-4 rounded-md shadow-sm">
       <CircularImage
-        imageUrl={getImgSrc(childInfo.gender, 'CHILD')}
-        altText="boy1"
+        imageUrl={getImgSrc(info.gender, type)}
+        altText={info.nickname}
         size="xl"
       />
       <div className="flex flex-col justify-between ml-4 gap-y-2">
         <div className="flex items-center">
           <Typography color="dark" size="sm">
-            {childInfo.name}
+            {info.name}
           </Typography>
         </div>
         <div className="flex items-center">
           <Typography color="dark" size="sm">
-            {childInfo.nickname}
+            {info.nickname}
           </Typography>
         </div>
         <div className="flex items-center">
           <Typography color="dark" size="sm">
-            {dayjs(childInfo.birthday).format('YYYY년 MM월 DD일')}
+            {dayjs(info.birthday).format('YYYY년 MM월 DD일')}
           </Typography>
         </div>
       </div>
-      {withTrash && (
+      {type === 'CHILD' && withTrash && (
         <Icon
           color="danger"
           classNameStyles="absolute right-4 top-4 mob:right-2 mob:top-2"
         >
-          <HiTrash onClick={() => mutate(childInfo.nickname)} />
+          <HiTrash onClick={() => mutate(info.nickname)} />
         </Icon>
       )}
     </div>

--- a/ssh-web/src/components/molecules/MascotCard/index.tsx
+++ b/ssh-web/src/components/molecules/MascotCard/index.tsx
@@ -4,16 +4,34 @@ import { CircularImage } from '../../atoms/CircularImage';
 import { Typography } from '../../atoms/Typography';
 import { Icon } from '../../atoms/Icon';
 import { HiTrash } from 'react-icons/hi2';
+import dayjs from 'dayjs';
+import { getImgSrc } from '../../../utils/userUtil';
+import { deleteMyChild, deleteMyWaitingChild } from '../../../apis/userApi';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export const MascotCard = ({
   childInfo,
+  isWaiting = false,
   children,
   classNameStyles,
 }: MascotCardProps) => {
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: async (nickname: string) =>
+      !isWaiting
+        ? await deleteMyChild(nickname)
+        : await deleteMyWaitingChild(nickname),
+    onSuccess: (res) => {
+      alert(res.data.description);
+      queryClient.invalidateQueries({ queryKey: ['children', 'waiting'] });
+    },
+    onError: (err) => alert(err.message),
+  });
+
   return (
     <div className="relative flex items-center w-full p-4 rounded-md shadow-sm">
       <CircularImage
-        imageUrl="/assets/images/samples/children/boy1.png"
+        imageUrl={getImgSrc(childInfo.gender, 'CHILD')}
         altText="boy1"
         size="xl"
       />
@@ -30,7 +48,7 @@ export const MascotCard = ({
         </div>
         <div className="flex items-center">
           <Typography color="dark" size="sm">
-            {childInfo.birthday}
+            {dayjs(childInfo.birthday).format('YYYY년 MM월 DD일')}
           </Typography>
         </div>
       </div>
@@ -38,7 +56,7 @@ export const MascotCard = ({
         color="danger"
         classNameStyles="absolute right-4 top-4 mob:right-2 mob:top-2"
       >
-        <HiTrash />
+        <HiTrash onClick={() => mutate(childInfo.nickname)} />
       </Icon>
     </div>
   );

--- a/ssh-web/src/components/molecules/MascotCard/index.tsx
+++ b/ssh-web/src/components/molecules/MascotCard/index.tsx
@@ -12,6 +12,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 export const MascotCard = ({
   childInfo,
   isWaiting = false,
+  withTrash = true,
   children,
   classNameStyles,
 }: MascotCardProps) => {
@@ -52,12 +53,14 @@ export const MascotCard = ({
           </Typography>
         </div>
       </div>
-      <Icon
-        color="danger"
-        classNameStyles="absolute right-4 top-4 mob:right-2 mob:top-2"
-      >
-        <HiTrash onClick={() => mutate(childInfo.nickname)} />
-      </Icon>
+      {withTrash && (
+        <Icon
+          color="danger"
+          classNameStyles="absolute right-4 top-4 mob:right-2 mob:top-2"
+        >
+          <HiTrash onClick={() => mutate(childInfo.nickname)} />
+        </Icon>
+      )}
     </div>
   );
 };

--- a/ssh-web/src/interfaces/userInterface.ts
+++ b/ssh-web/src/interfaces/userInterface.ts
@@ -16,6 +16,7 @@ export interface IContentHandler {
 }
 
 export interface ISignupRequest {
+  code: string;
   nickname: string;
   birthday: string;
   gender: 'MALE' | 'FEMALE';

--- a/ssh-web/src/interfaces/userInterface.ts
+++ b/ssh-web/src/interfaces/userInterface.ts
@@ -23,6 +23,15 @@ export interface ISignupRequest {
   type: 'PARENT' | 'CHILD';
 }
 
+export interface IUserInfo {
+  nickname: string;
+  email: string;
+  name: string;
+  gender: string;
+  birthday: string;
+  type: string;
+}
+
 export interface IUserInfoInfo {
   label: string;
   content: string;
@@ -37,4 +46,5 @@ export interface IChild {
   name: string;
   nickname: string;
   birthday: string;
+  gender: string;
 }

--- a/ssh-web/src/interfaces/userInterface.ts
+++ b/ssh-web/src/interfaces/userInterface.ts
@@ -19,8 +19,8 @@ export interface ISignupRequest {
   code: string;
   nickname: string;
   birthday: string;
-  gender: 'MALE' | 'FEMALE';
-  type: 'parent' | 'child';
+  gender: 'M' | 'F';
+  type: 'PARENT' | 'CHILD';
 }
 
 export interface IUserInfoInfo {

--- a/ssh-web/src/interfaces/userInterface.ts
+++ b/ssh-web/src/interfaces/userInterface.ts
@@ -48,3 +48,10 @@ export interface IChild {
   birthday: string;
   gender: string;
 }
+
+export interface IParent {
+  name: string;
+  nickname: string;
+  birthday: string;
+  gender: string;
+}

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -488,7 +488,7 @@ mock.onGet('/api/users/info').reply((config) => {
           name: '이유승',
           gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
           birthday: '1998-04-29',
-          type: Math.floor(Math.random() * 2) ? 'PARENT' : 'CHILD', // "CHILD"
+          type: Math.floor(Math.random() * 2) ? 'PARENT' : 'CHILD',
         },
       ]);
     }, 500);
@@ -505,13 +505,13 @@ mock.onGet('/api/parents/children').reply((config) => {
             name: '김다운',
             nickname: '흑룡',
             birthday: '1999-06-30',
-            gender: 'M',
+            gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
           },
           {
             name: '양규현',
             nickname: '백룡',
             birthday: '1999-05-30',
-            gender: 'F',
+            gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
           },
         ],
       ]);
@@ -528,7 +528,63 @@ mock.onGet('/api/children/parents').reply((config) => {
           name: '부모님',
           nickname: '부모님닉네임',
           birthday: '1970-03-13',
-          gender: 'M',
+          gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+        },
+      ]);
+    }, 500);
+  });
+});
+
+mock.onGet('/api/parents/children/waiting').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        [
+          {
+            name: '권용진',
+            nickname: '흑룡도포기한남자',
+            birthday: '1997-05-17',
+            gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+          },
+          {
+            name: '이유승',
+            nickname: '뼛속까지섹시녀',
+            birthday: '1998-04-29',
+            gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+          },
+        ],
+      ]);
+    }, 500);
+  });
+});
+
+mock.onPatch('/api/parents/children').reply((config) => {
+  const target = JSON.parse(config.data).nickname;
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        201,
+        {
+          code: null,
+          description: '등록된 자식 삭제 성공',
+        },
+      ]);
+    }, 500);
+  });
+});
+
+mock.onPatch('/api/parents/children/waiting').reply((config) => {
+  const target = JSON.parse(config.data).nickname;
+
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        201,
+        {
+          code: null,
+          description: '등록된 자식 신청 삭제 성공',
         },
       ]);
     }, 500);

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -477,7 +477,25 @@ mock.onPatch(/\/api\/missions\/\d+/).reply((config) => {
 // ========== 미션 도메인 ==========
 
 // ========== 사용자 도메인 ==========
-mock.onGet('/api/parents/childrens').reply((config) => {
+mock.onGet('/api/users/info').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        {
+          nickname: 'yuseung0429',
+          email: 'yuseung0429@naver.com',
+          name: '이유승',
+          gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+          birthday: '1998-04-29',
+          type: Math.floor(Math.random() * 2) ? 'PARENT' : 'CHILD', // "CHILD"
+        },
+      ]);
+    }, 500);
+  });
+});
+
+mock.onGet('/api/parents/children').reply((config) => {
   return new Promise((resolve) => {
     setTimeout(() => {
       resolve([

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -559,6 +559,22 @@ mock.onGet('/api/parents/children/waiting').reply((config) => {
   });
 });
 
+mock.onGet('/api/children/parents/waiting').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        {
+          name: '권용진',
+          nickname: '흑룡도포기한남자',
+          birthday: '1997-05-17',
+          gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+        },
+      ]);
+    }, 500);
+  });
+});
+
 mock.onPatch('/api/parents/children').reply((config) => {
   const target = JSON.parse(config.data).nickname;
 

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -591,4 +591,48 @@ mock.onPatch('/api/parents/children/waiting').reply((config) => {
   });
 });
 
+mock.onPost('/api/children').reply((config) => {
+  const target = JSON.parse(config.data).nickname;
+
+  return target === '귀요미요하'
+    ? new Promise((resolve) => {
+        setTimeout(() => {
+          resolve([
+            200,
+            {
+              name: '김다운',
+              nickname: '귀욤다운',
+              birthday: '1999-06-30',
+              gender: Math.floor(Math.random() * 2) ? 'MALE' : 'FEMALE',
+            },
+          ]);
+        }, 500);
+      })
+    : new Promise((resolve) => {
+        setTimeout(() => {
+          resolve([
+            404,
+            {
+              code: 'U003',
+              description: '존재하지 않는 사용자',
+            },
+          ]);
+        }, 500);
+      });
+});
+
+mock.onPost('/api/parents/children/request').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        202,
+        {
+          code: null,
+          description: '자식 신청 성공',
+        },
+      ]);
+    }, 500);
+  });
+});
+
 // ========== 사용자 도메인 ==========

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -501,4 +501,20 @@ mock.onGet('/api/parents/childrens').reply((config) => {
   });
 });
 
+mock.onGet('/api/children/parents').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        {
+          name: '부모님',
+          nickname: '부모님닉네임',
+          birthday: '1970-03-13',
+          gender: 'M',
+        },
+      ]);
+    }, 500);
+  });
+});
+
 // ========== 사용자 도메인 ==========

--- a/ssh-web/src/mocks/index.ts
+++ b/ssh-web/src/mocks/index.ts
@@ -475,3 +475,30 @@ mock.onPatch(/\/api\/missions\/\d+/).reply((config) => {
   });
 });
 // ========== 미션 도메인 ==========
+
+// ========== 사용자 도메인 ==========
+mock.onGet('/api/parents/childrens').reply((config) => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve([
+        200,
+        [
+          {
+            name: '김다운',
+            nickname: '흑룡',
+            birthday: '1999-06-30',
+            gender: 'M',
+          },
+          {
+            name: '양규현',
+            nickname: '백룡',
+            birthday: '1999-05-30',
+            gender: 'F',
+          },
+        ],
+      ]);
+    }, 500);
+  });
+});
+
+// ========== 사용자 도메인 ==========

--- a/ssh-web/src/pages/Information/InformationFetch.tsx
+++ b/ssh-web/src/pages/Information/InformationFetch.tsx
@@ -81,7 +81,10 @@ export const InformationFetch = () => {
           type="mascot"
           title={`${userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'} 정보`}
           mascots={related}
-          hasMore
+          mascotType={
+            userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'
+          }
+          hasMore={userinfoQuery.data.data.type === 'PARENT'}
         />
       </div>
     </div>

--- a/ssh-web/src/pages/Information/InformationFetch.tsx
+++ b/ssh-web/src/pages/Information/InformationFetch.tsx
@@ -92,7 +92,7 @@ export const InformationFetch = () => {
           title={`${userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'} 정보`}
           mascots={related}
           mascotType={userinfoQuery.data.data.type}
-          hasMore={userinfoQuery.data.data.type === 'PARENT'}
+          hasMore
         />
       </div>
     </div>

--- a/ssh-web/src/pages/Information/InformationFetch.tsx
+++ b/ssh-web/src/pages/Information/InformationFetch.tsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from 'react';
+import { containerStyles, contentStyles } from './styles';
+import { CircularImage } from '../../components/atoms/CircularImage';
+import { Mascot } from '../../components/molecules/Mascot';
+import { InfoList } from '../../components/molecules/InfoList';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getMyChildren, getUserInfo } from '../../apis/userApi';
+import { getImgSrc } from '../../utils/userUtil';
+import dayjs from 'dayjs';
+import { IChild, IUserInfoMascot } from '../../interfaces/userInterface';
+
+export const InformationFetch = () => {
+  const userinfoQuery = useSuspenseQuery({
+    queryKey: ['userinfo'],
+    queryFn: async () => await getUserInfo(),
+  });
+
+  if (userinfoQuery.error && !userinfoQuery.isFetching) {
+    throw userinfoQuery.error;
+  }
+
+  const [related, setRelated] = useState<IUserInfoMascot[]>([]);
+
+  useEffect(() => {
+    if (userinfoQuery.data.data.type === 'PARENT') {
+      getMyChildren()
+        .then((res) => {
+          setRelated(() => {
+            const newRelated: IUserInfoMascot[] = [];
+            res.data.forEach((child: IChild) => {
+              const newUserInfoMascot: IUserInfoMascot = {
+                src: getImgSrc(child.gender, 'CHILD'),
+                label: child.nickname,
+              };
+              newRelated.push(newUserInfoMascot);
+            });
+            return newRelated;
+          });
+        })
+        .catch((err) => console.log(err));
+    }
+  }, []);
+
+  return (
+    <div className={containerStyles()}>
+      <Mascot
+        nickname={userinfoQuery.data.data.nickname}
+        ment="무엇이 궁금하신가요?"
+      />
+      <div className={contentStyles()}>
+        <CircularImage
+          imageUrl={getImgSrc(
+            userinfoQuery.data.data.gender,
+            userinfoQuery.data.data.type,
+          )}
+          altText={userinfoQuery.data.data.nickname}
+          size="xl"
+        />
+        <InfoList
+          type="info"
+          title="내 정보"
+          infos={[
+            {
+              label: '이름',
+              content: userinfoQuery.data.data.name,
+            },
+            {
+              label: '닉네임',
+              content: userinfoQuery.data.data.nickname,
+            },
+            {
+              label: '생년월일',
+              content: dayjs(userinfoQuery.data.data.birthday).format(
+                'YYYY년 MM월 DD일',
+              ),
+            },
+          ]}
+          hasMore={false}
+        />
+        <InfoList
+          type="mascot"
+          title={`${userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'} 정보`}
+          mascots={related}
+          hasMore
+        />
+      </div>
+    </div>
+  );
+};

--- a/ssh-web/src/pages/Information/InformationFetch.tsx
+++ b/ssh-web/src/pages/Information/InformationFetch.tsx
@@ -4,7 +4,7 @@ import { CircularImage } from '../../components/atoms/CircularImage';
 import { Mascot } from '../../components/molecules/Mascot';
 import { InfoList } from '../../components/molecules/InfoList';
 import { useSuspenseQuery } from '@tanstack/react-query';
-import { getMyChildren, getUserInfo } from '../../apis/userApi';
+import { getMyChildren, getMyParents, getUserInfo } from '../../apis/userApi';
 import { getImgSrc } from '../../utils/userUtil';
 import dayjs from 'dayjs';
 import { IChild, IUserInfoMascot } from '../../interfaces/userInterface';
@@ -38,6 +38,16 @@ export const InformationFetch = () => {
           });
         })
         .catch((err) => console.log(err));
+    } else {
+      getMyParents().then((res) => {
+        setRelated(() => {
+          const newUserInfoMascot: IUserInfoMascot = {
+            src: getImgSrc(res.data.gender, 'PARENT'),
+            label: res.data.nickname,
+          };
+          return [newUserInfoMascot];
+        });
+      });
     }
   }, []);
 
@@ -81,9 +91,7 @@ export const InformationFetch = () => {
           type="mascot"
           title={`${userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'} 정보`}
           mascots={related}
-          mascotType={
-            userinfoQuery.data.data.type === 'PARENT' ? '자녀' : '부모'
-          }
+          mascotType={userinfoQuery.data.data.type}
           hasMore={userinfoQuery.data.data.type === 'PARENT'}
         />
       </div>

--- a/ssh-web/src/pages/Information/Manage/ManageChildFetch.tsx
+++ b/ssh-web/src/pages/Information/Manage/ManageChildFetch.tsx
@@ -18,7 +18,7 @@ import { getImgSrc } from '../../../utils/userUtil';
 import { IChild } from '../../../interfaces/userInterface';
 import { useNavigate } from 'react-router-dom';
 
-export const ManageFetch = () => {
+export const ManageChildFetch = () => {
   const [userinfoQuery, childrenQuery, waitingQuery] = useSuspenseQueries({
     queries: [
       {
@@ -93,7 +93,8 @@ export const ManageFetch = () => {
               return (
                 <MascotCard
                   key={child.nickname}
-                  childInfo={child}
+                  info={child}
+                  type="CHILD"
                   isWaiting={activeTab ? true : false}
                 />
               );

--- a/ssh-web/src/pages/Information/Manage/ManageFetch.tsx
+++ b/ssh-web/src/pages/Information/Manage/ManageFetch.tsx
@@ -1,0 +1,113 @@
+import React, { useState } from 'react';
+import { containerStyles, contentStyles, infoBoxStyles } from './styles';
+import { Mascot } from '../../../components/molecules/Mascot';
+import { Icon } from '../../../components/atoms/Icon';
+import { HiChevronLeft } from 'react-icons/hi2';
+import { Typography } from '../../../components/atoms/Typography';
+import { AvatarWithLabel } from '../../../components/molecules/AvatarWithLabel';
+import { ToggleTab } from '../../../components/atoms/ToggleTab';
+import { MascotCard } from '../../../components/molecules/MascotCard';
+import { Button } from '../../../components/atoms/Button';
+import { useSuspenseQueries } from '@tanstack/react-query';
+import {
+  getMyChildren,
+  getMyWaitingChildren,
+  getUserInfo,
+} from '../../../apis/userApi';
+import { getImgSrc } from '../../../utils/userUtil';
+import { IChild } from '../../../interfaces/userInterface';
+import { useNavigate } from 'react-router-dom';
+
+export const ManageFetch = () => {
+  const [userinfoQuery, childrenQuery, waitingQuery] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: ['userinfo'],
+        queryFn: async () => await getUserInfo(),
+      },
+      {
+        queryKey: ['children'],
+        queryFn: async () => await getMyChildren(),
+      },
+      {
+        queryKey: ['waiting'],
+        queryFn: async () => await getMyWaitingChildren(),
+      },
+    ],
+  });
+
+  [userinfoQuery, childrenQuery, waitingQuery].some((query) => {
+    if (query.error && !query.isFetching) {
+      throw query.error;
+    }
+  });
+
+  const nav = useNavigate();
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const onTabChange = () => {
+    setActiveTab((prev) => {
+      if (prev) return 0;
+      else return 1;
+    });
+  };
+  return (
+    <div className={containerStyles()}>
+      <Mascot
+        nickname={userinfoQuery.data.data.nickname}
+        ment="자녀 정보가 궁금하시군요!!"
+        classNameStyles="tablet:hidden"
+      />
+      <div className={contentStyles()}>
+        <div className={infoBoxStyles()}>
+          <div className="flex justify-center w-full">
+            <Icon
+              color="dark"
+              classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
+            >
+              <HiChevronLeft />
+            </Icon>
+            <Typography weight="bold" size="xl" color="dark">
+              자녀 정보
+            </Typography>
+          </div>
+          <AvatarWithLabel
+            imageUrl={getImgSrc(userinfoQuery.data.data.gender, 'PARENT')}
+            label={userinfoQuery.data.data.nickname}
+            altText="avatarwithlabel"
+            size="2xl"
+            classNameStyles="mt-4"
+          />
+          <div className="w-full mt-4">
+            <ToggleTab
+              activeTab={activeTab}
+              onTabChange={onTabChange}
+              labels={['등록된 자녀', '등록 대기중']}
+              outlined
+            />
+          </div>
+          <div className="flex flex-col w-full mt-4 gap-y-4">
+            {(!activeTab
+              ? childrenQuery.data.data
+              : waitingQuery.data.data
+            ).map((child: IChild) => {
+              return (
+                <MascotCard
+                  key={child.nickname}
+                  childInfo={child}
+                  isWaiting={activeTab ? true : false}
+                />
+              );
+            })}
+          </div>
+        </div>
+        <div className="w-full desktop:px-36 tabletB:px-20 mob:px-8 bottom-16">
+          <Button fullWidth onClick={() => nav('/request')}>
+            <Typography weight="bold" size="sm" color="light">
+              자녀 초대하기
+            </Typography>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ssh-web/src/pages/Information/Manage/ManageFetch.tsx
+++ b/ssh-web/src/pages/Information/Manage/ManageFetch.tsx
@@ -64,7 +64,7 @@ export const ManageFetch = () => {
               color="dark"
               classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
             >
-              <HiChevronLeft />
+              <HiChevronLeft onClick={() => nav('/mypage')} />
             </Icon>
             <Typography weight="bold" size="xl" color="dark">
               자녀 정보

--- a/ssh-web/src/pages/Information/Manage/ManageParentFetch.tsx
+++ b/ssh-web/src/pages/Information/Manage/ManageParentFetch.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { containerStyles, contentStyles, infoBoxStyles } from './styles';
+import { Mascot } from '../../../components/molecules/Mascot';
+import { Icon } from '../../../components/atoms/Icon';
+import { HiChevronLeft } from 'react-icons/hi2';
+import { Typography } from '../../../components/atoms/Typography';
+import { AvatarWithLabel } from '../../../components/molecules/AvatarWithLabel';
+import { ToggleTab } from '../../../components/atoms/ToggleTab';
+import { MascotCard } from '../../../components/molecules/MascotCard';
+import { useSuspenseQueries } from '@tanstack/react-query';
+import {
+  getMyParents,
+  getMyWaitingParent,
+  getUserInfo,
+} from '../../../apis/userApi';
+import { getImgSrc } from '../../../utils/userUtil';
+import { IChild } from '../../../interfaces/userInterface';
+import { useNavigate } from 'react-router-dom';
+
+export const ManageParentFetch = () => {
+  const [userinfoQuery, parentsQuery, waitingQuery] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: ['userinfo'],
+        queryFn: async () => await getUserInfo(),
+      },
+      {
+        queryKey: ['parents'],
+        queryFn: async () => await getMyParents(),
+      },
+      {
+        queryKey: ['waiting'],
+        queryFn: async () => await getMyWaitingParent(),
+      },
+    ],
+  });
+
+  [userinfoQuery, parentsQuery, waitingQuery].some((query) => {
+    if (query.error && !query.isFetching) {
+      throw query.error;
+    }
+  });
+
+  const nav = useNavigate();
+  const [activeTab, setActiveTab] = useState<number>(0);
+  const onTabChange = () => {
+    setActiveTab((prev) => {
+      if (prev) return 0;
+      else return 1;
+    });
+  };
+  return (
+    <div className={containerStyles()}>
+      <Mascot
+        nickname={userinfoQuery.data.data.nickname}
+        ment="부모 정보가 궁금하시군요!!"
+        classNameStyles="tablet:hidden"
+      />
+      <div className={contentStyles()}>
+        <div className={infoBoxStyles()}>
+          <div className="flex justify-center w-full">
+            <Icon
+              color="dark"
+              classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
+            >
+              <HiChevronLeft onClick={() => nav('/mypage')} />
+            </Icon>
+            <Typography weight="bold" size="xl" color="dark">
+              부모 정보
+            </Typography>
+          </div>
+          <AvatarWithLabel
+            imageUrl={getImgSrc(userinfoQuery.data.data.gender, 'PARENT')}
+            label={userinfoQuery.data.data.nickname}
+            altText="avatarwithlabel"
+            size="2xl"
+            classNameStyles="mt-4"
+          />
+          <div className="w-full mt-4">
+            <ToggleTab
+              activeTab={activeTab}
+              onTabChange={onTabChange}
+              labels={['연결된 부모', '신청 대기중']}
+              outlined
+            />
+          </div>
+          <div className="flex flex-col w-full mt-4 gap-y-4">
+            {(!activeTab
+              ? [parentsQuery.data.data]
+              : [waitingQuery.data.data]
+            ).map((parent: IChild) => {
+              return (
+                <MascotCard
+                  key={parent.nickname}
+                  info={parent}
+                  type="PARENT"
+                  isWaiting={false}
+                  withTrash={false}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ssh-web/src/pages/Information/Manage/index.tsx
+++ b/ssh-web/src/pages/Information/Manage/index.tsx
@@ -59,6 +59,7 @@ export const Manage = () => {
                 name: '자녀1',
                 nickname: '자녀1 닉네임',
                 birthday: '1999-03-13',
+                gender: 'M',
               }}
             />
           </div>

--- a/ssh-web/src/pages/Information/Manage/index.tsx
+++ b/ssh-web/src/pages/Information/Manage/index.tsx
@@ -1,77 +1,13 @@
-import React, { useState } from 'react';
-import { containerStyles, contentStyles, infoBoxStyles } from './styles';
-import { Mascot } from '../../../components/molecules/Mascot';
-import { Typography } from '../../../components/atoms/Typography';
-import { HiChevronLeft } from 'react-icons/hi2';
-import { Icon } from '../../../components/atoms/Icon';
-import { AvatarWithLabel } from '../../../components/molecules/AvatarWithLabel';
-import { ToggleTab } from '../../../components/atoms/ToggleTab';
-import { MascotCard } from '../../../components/molecules/MascotCard';
-import { Button } from '../../../components/atoms/Button';
+import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { ManageFetch } from './ManageFetch';
 
 export const Manage = () => {
-  const [activeTab, setActiveTab] = useState<number>(0);
-  const onTabChange = () => {
-    setActiveTab((prev) => {
-      if (prev) return 0;
-      else return 1;
-    });
-  };
-
   return (
-    <div className={containerStyles()}>
-      <Mascot
-        nickname="닉네임"
-        ment="자녀 정보가 궁금하시군요!!"
-        classNameStyles="tablet:hidden"
-      />
-      <div className={contentStyles()}>
-        <div className={infoBoxStyles()}>
-          <div className="flex justify-center w-full">
-            <Icon
-              color="dark"
-              classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
-            >
-              <HiChevronLeft />
-            </Icon>
-            <Typography weight="bold" size="xl" color="dark">
-              자녀 정보
-            </Typography>
-          </div>
-          <AvatarWithLabel
-            imageUrl="/assets/images/samples/parent/man1.png"
-            label="최요하(닉네임입니다)"
-            altText="avatarwithlabel"
-            size="2xl"
-            classNameStyles="mt-4"
-          />
-          <div className="w-full mt-4">
-            <ToggleTab
-              activeTab={activeTab}
-              onTabChange={onTabChange}
-              labels={['등록된 자녀', '등록 대기중']}
-              outlined
-            />
-          </div>
-          <div className="w-full mt-4">
-            <MascotCard
-              childInfo={{
-                name: '자녀1',
-                nickname: '자녀1 닉네임',
-                birthday: '1999-03-13',
-                gender: 'M',
-              }}
-            />
-          </div>
-        </div>
-        <div className="w-full desktop:px-36 tabletB:px-20 mob:px-8 bottom-16">
-          <Button fullWidth>
-            <Typography weight="bold" size="sm" color="light">
-              자녀 초대하기
-            </Typography>
-          </Button>
-        </div>
-      </div>
-    </div>
+    <ErrorBoundary fallback={<>에러</>}>
+      <Suspense fallback={<>로딩중</>}>
+        <ManageFetch />
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/ssh-web/src/pages/Information/Manage/index.tsx
+++ b/ssh-web/src/pages/Information/Manage/index.tsx
@@ -1,13 +1,27 @@
 import React, { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { ManageFetch } from './ManageFetch';
+import { ManageChildFetch } from './ManageChildFetch';
+import { useLocation } from 'react-router-dom';
+import { ManageParentFetch } from './ManageParentFetch';
 
 export const Manage = () => {
+  const location = useLocation();
   return (
-    <ErrorBoundary fallback={<>에러</>}>
-      <Suspense fallback={<>로딩중</>}>
-        <ManageFetch />
-      </Suspense>
-    </ErrorBoundary>
+    <>
+      {location.state?.type === 'PARENT' && (
+        <ErrorBoundary fallback={<>에러</>}>
+          <Suspense fallback={<>로딩중</>}>
+            <ManageChildFetch />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+      {location.state?.type === 'CHILD' && (
+        <ErrorBoundary fallback={<>에러</>}>
+          <Suspense fallback={<>로딩중</>}>
+            <ManageParentFetch />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </>
   );
 };

--- a/ssh-web/src/pages/Information/Request/RequestFetch.tsx
+++ b/ssh-web/src/pages/Information/Request/RequestFetch.tsx
@@ -1,0 +1,126 @@
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import React, { useCallback, useState } from 'react';
+import { containerStyles, contentStyles } from './styles';
+import {
+  findChildByNickname,
+  getUserInfo,
+  requestChild,
+} from '../../../apis/userApi';
+import { Mascot } from '../../../components/molecules/Mascot';
+import { infoBoxStyles } from '../Manage/styles';
+import { Icon } from '../../../components/atoms/Icon';
+import { HiChevronLeft } from 'react-icons/hi2';
+import { useNavigate } from 'react-router-dom';
+import { Typography } from '../../../components/atoms/Typography';
+import { AvatarWithLabel } from '../../../components/molecules/AvatarWithLabel';
+import { getImgSrc } from '../../../utils/userUtil';
+import { HiMagnifyingGlass } from 'react-icons/hi2';
+import TextField from '../../../components/atoms/TextField';
+import { IChild } from '../../../interfaces/userInterface';
+import { MascotCard } from '../../../components/molecules/MascotCard';
+import { Button } from '../../../components/atoms/Button';
+import { showToast } from '../../../utils/toastUtil';
+
+export const RequestFetch = () => {
+  const userinfoQuery = useSuspenseQuery({
+    queryKey: ['userinfo'],
+    queryFn: async () => await getUserInfo(),
+  });
+
+  if (userinfoQuery.error && !userinfoQuery.isFetching) {
+    throw userinfoQuery.error;
+  }
+
+  const nav = useNavigate();
+  const [nickname, setNickname] = useState<string>('');
+  const [child, setChild] = useState<IChild | null>(null);
+  const onChangeNickname = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setNickname(() => e.target.value);
+    },
+    [nickname],
+  );
+
+  const { mutate } = useMutation({
+    mutationFn: async (nickname: string) => await requestChild(nickname),
+    onSuccess: (res) => {
+      showToast('success', res.data.description);
+      nav('/manage');
+    },
+    onError: () => showToast('error', '자식 신청에 실패했습니다'),
+  });
+
+  return (
+    <div className={containerStyles()}>
+      <Mascot
+        nickname={userinfoQuery.data.data.nickname}
+        ment="자녀 정보가 궁금하시군요!!"
+        classNameStyles="tablet:hidden"
+      />
+      <div className={contentStyles()}>
+        <div className={infoBoxStyles()}>
+          <div className="flex justify-center w-full">
+            <Icon
+              color="dark"
+              classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
+            >
+              <HiChevronLeft onClick={() => nav('/manage')} />
+            </Icon>
+            <Typography weight="bold" size="xl" color="dark">
+              자녀 초대하기
+            </Typography>
+          </div>
+          <AvatarWithLabel
+            imageUrl={getImgSrc(userinfoQuery.data.data.gender, 'PARENT')}
+            label={userinfoQuery.data.data.nickname}
+            altText="avatarwithlabel"
+            size="2xl"
+            classNameStyles="mt-4"
+          />
+          <div className="relative w-full mt-4">
+            <TextField label="닉네임" onChange={onChangeNickname} fullWidth />
+            <Icon
+              color="dark"
+              size="sm"
+              classNameStyles="absolute top-4 right-4"
+            >
+              <HiMagnifyingGlass
+                onClick={async () => {
+                  await findChildByNickname(nickname)
+                    .then((res) => setChild(res.data))
+                    .catch(() => setChild(null));
+                }}
+              />
+            </Icon>
+          </div>
+          <div
+            className={`w-full mt-4 ${child ? '' : 'flex justify-center items-center p-8'}`}
+          >
+            {child ? (
+              <MascotCard
+                key={child.nickname}
+                childInfo={child}
+                withTrash={false}
+              />
+            ) : (
+              '자녀가 존재하지 않습니다'
+            )}
+          </div>
+        </div>
+        <div className="w-full desktop:px-36 tabletB:px-20 mob:px-8 bottom-16">
+          <Button
+            fullWidth
+            onClick={() => {
+              if (child) mutate(child.nickname);
+              else showToast('error', '초대할 자녀를 검색해주세요');
+            }}
+          >
+            <Typography weight="bold" size="sm" color="light">
+              초대하기
+            </Typography>
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/ssh-web/src/pages/Information/Request/RequestFetch.tsx
+++ b/ssh-web/src/pages/Information/Request/RequestFetch.tsx
@@ -45,7 +45,7 @@ export const RequestFetch = () => {
     mutationFn: async (nickname: string) => await requestChild(nickname),
     onSuccess: (res) => {
       showToast('success', res.data.description);
-      nav('/manage');
+      nav('/manage', { state: { type: userinfoQuery.data.data.type } });
     },
     onError: () => showToast('error', '자식 신청에 실패했습니다'),
   });
@@ -64,7 +64,13 @@ export const RequestFetch = () => {
               color="dark"
               classNameStyles="absolute desktop:left-36 tabletB:left-20 mob:left-8"
             >
-              <HiChevronLeft onClick={() => nav('/manage')} />
+              <HiChevronLeft
+                onClick={() =>
+                  nav('/manage', {
+                    state: { type: userinfoQuery.data.data.type },
+                  })
+                }
+              />
             </Icon>
             <Typography weight="bold" size="xl" color="dark">
               자녀 초대하기
@@ -99,7 +105,8 @@ export const RequestFetch = () => {
             {child ? (
               <MascotCard
                 key={child.nickname}
-                childInfo={child}
+                info={child}
+                type="CHILD"
                 withTrash={false}
               />
             ) : (

--- a/ssh-web/src/pages/Information/Request/index.tsx
+++ b/ssh-web/src/pages/Information/Request/index.tsx
@@ -1,0 +1,13 @@
+import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { RequestFetch } from './RequestFetch';
+
+export const Request = () => {
+  return (
+    <ErrorBoundary fallback={<>에러</>}>
+      <Suspense fallback={<>로딩중</>}>
+        <RequestFetch />
+      </Suspense>
+    </ErrorBoundary>
+  );
+};

--- a/ssh-web/src/pages/Information/Request/styles.ts
+++ b/ssh-web/src/pages/Information/Request/styles.ts
@@ -1,0 +1,13 @@
+import { tv } from 'tailwind-variants';
+
+export const containerStyles = tv({
+  base: 'flex items-center justify-center w-full h-auto tablet:flex-col',
+});
+
+export const contentStyles = tv({
+  base: 'flex flex-col items-center justify-between gap-y-4 bg-white desktop:w-[48rem] desktop:h-[48rem] desktop:rounded-lg desktop:py-12 tablet:w-full tablet:h-full tablet:py-8',
+});
+
+export const infoBoxStyles = tv({
+  base: 'relative w-full desktop:px-36 tabletB:px-20 mob:px-8',
+});

--- a/ssh-web/src/pages/Information/index.tsx
+++ b/ssh-web/src/pages/Information/index.tsx
@@ -1,54 +1,13 @@
-import React from 'react';
-import { Mascot } from '../../components/molecules/Mascot';
-import { containerStyles, contentStyles } from './styles';
-import { CircularImage } from '../../components/atoms/CircularImage';
-import { InfoList } from '../../components/molecules/InfoList';
+import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import { InformationFetch } from './InformationFetch';
 
 export const Information = () => {
   return (
-    <div className={containerStyles()}>
-      <Mascot nickname="닉네임" ment="무엇이 궁금하신가요?" />
-      <div className={contentStyles()}>
-        <CircularImage
-          imageUrl="/assets/images/samples/parent/man1.png"
-          altText="부모님 이미지"
-          size="xl"
-        />
-        <InfoList
-          type="info"
-          title="내 정보"
-          infos={[
-            {
-              label: '이름',
-              content: '최요하',
-            },
-            {
-              label: '닉네임',
-              content: '닉네임입니다',
-            },
-            {
-              label: '생년월일',
-              content: '1999.03.13',
-            },
-          ]}
-          hasMore={false}
-        />
-        <InfoList
-          type="mascot"
-          title="자녀 정보"
-          mascots={[
-            {
-              src: '/assets/images/samples/children/boy1.png',
-              label: '아들 닉네임',
-            },
-            {
-              src: '/assets/images/samples/children/girl1.png',
-              label: '딸 닉네임',
-            },
-          ]}
-          hasMore
-        />
-      </div>
-    </div>
+    <ErrorBoundary fallback={<>에러</>}>
+      <Suspense fallback={<>로딩중</>}>
+        <InformationFetch />
+      </Suspense>
+    </ErrorBoundary>
   );
 };

--- a/ssh-web/src/pages/Login/index.tsx
+++ b/ssh-web/src/pages/Login/index.tsx
@@ -1,9 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Typography } from '../../components/atoms/Typography';
 import { LoginNav } from '../../components/molecules/LoginNav';
 import { containerStyles } from './styles';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export const Login = () => {
+  const location = useLocation();
+  const nav = useNavigate();
+
+  useEffect(() => {
+    const queryParams = new URLSearchParams(location.search);
+    console.log(queryParams);
+    if (queryParams.get('status') === 'U004') {
+      nav('/signup', { state: { code: queryParams.get('code') } });
+    }
+  }, [location]);
+
   return (
     <div className={containerStyles()}>
       <Typography

--- a/ssh-web/src/pages/Signup/index.tsx
+++ b/ssh-web/src/pages/Signup/index.tsx
@@ -9,8 +9,18 @@ import {
 } from '../../interfaces/userInterface';
 import dayjs from 'dayjs';
 import { BirthdayForm } from '../../components/organisms/BirthdayForm';
+import { useMutation } from '@tanstack/react-query';
+import { signup } from '../../apis/userApi';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export const Signup = () => {
+  const nav = useNavigate();
+  const location = useLocation();
+  const { mutate } = useMutation({
+    mutationFn: async (request: ISignupRequest) => await signup(request),
+    onSuccess: () => nav('/'),
+    onError: () => alert('오류가 발생하였습니다.'),
+  });
   const [pageType, setPageType] = useState<string>('info');
   const [contents, setContents] = useState<IContent[]>([
     {
@@ -45,7 +55,6 @@ export const Signup = () => {
       valueList: ['부모', '자녀'],
     },
   ]);
-
   const onContentHandler = useCallback(
     (idx: number, value: ReactNode) => {
       setContents((prev) => {
@@ -60,12 +69,13 @@ export const Signup = () => {
     label: '회원가입',
     handler: () => {
       const info: ISignupRequest = {
+        code: location.state?.code,
         nickname: contents[0].value as string,
         birthday: contents[1].value as string,
         gender: contents[2].value === '남' ? 'MALE' : 'FEMALE',
         type: contents[3].value === '부모' ? 'parent' : 'child',
       };
-      console.log(info);
+      mutate(info);
     },
   });
   const birthdayHandler = (year: number, month: number, day: number) => {

--- a/ssh-web/src/pages/Signup/index.tsx
+++ b/ssh-web/src/pages/Signup/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useState } from 'react';
+import React, { ReactNode, useCallback, useEffect, useState } from 'react';
 import { Mascot } from '../../components/molecules/Mascot';
 import { contentStyles } from './style';
 import { UserInfoForm } from '../../components/organisms/UserInfoForm';
@@ -16,6 +16,10 @@ import { useLocation, useNavigate } from 'react-router-dom';
 export const Signup = () => {
   const nav = useNavigate();
   const location = useLocation();
+  useEffect(() => {
+    console.log(location);
+    console.log(location.state);
+  }, []);
   const { mutate } = useMutation({
     mutationFn: async (request: ISignupRequest) => await signup(request),
     onSuccess: () => nav('/'),
@@ -67,7 +71,7 @@ export const Signup = () => {
   );
   const [handler, setHandler] = useState<IContentHandler>({
     label: '회원가입',
-    handler: () => {
+    handler: async () => {
       const info: ISignupRequest = {
         code: location.state?.code,
         nickname: contents[0].value as string,
@@ -75,7 +79,9 @@ export const Signup = () => {
         gender: contents[2].value === '남' ? 'MALE' : 'FEMALE',
         type: contents[3].value === '부모' ? 'parent' : 'child',
       };
-      mutate(info);
+      await signup(info)
+        .then((res) => console.log(res.data))
+        .catch((err) => console.log(err));
     },
   });
   const birthdayHandler = (year: number, month: number, day: number) => {

--- a/ssh-web/src/pages/Signup/index.tsx
+++ b/ssh-web/src/pages/Signup/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useCallback, useEffect, useState } from 'react';
+import React, { ReactNode, useCallback, useState } from 'react';
 import { Mascot } from '../../components/molecules/Mascot';
 import { contentStyles } from './style';
 import { UserInfoForm } from '../../components/organisms/UserInfoForm';
@@ -9,21 +9,17 @@ import {
 } from '../../interfaces/userInterface';
 import dayjs from 'dayjs';
 import { BirthdayForm } from '../../components/organisms/BirthdayForm';
-import { useMutation } from '@tanstack/react-query';
 import { signup } from '../../apis/userApi';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { useMutation } from '@tanstack/react-query';
 
 export const Signup = () => {
-  const nav = useNavigate();
   const location = useLocation();
-  useEffect(() => {
-    console.log(location);
-    console.log(location.state);
-  }, []);
+  const nav = useNavigate();
   const { mutate } = useMutation({
     mutationFn: async (request: ISignupRequest) => await signup(request),
     onSuccess: () => nav('/'),
-    onError: () => alert('오류가 발생하였습니다.'),
+    onError: (err) => console.log(err),
   });
   const [pageType, setPageType] = useState<string>('info');
   const [contents, setContents] = useState<IContent[]>([
@@ -71,17 +67,14 @@ export const Signup = () => {
   );
   const [handler, setHandler] = useState<IContentHandler>({
     label: '회원가입',
-    handler: async () => {
-      const info: ISignupRequest = {
+    handler: () => {
+      mutate({
         code: location.state?.code,
         nickname: contents[0].value as string,
         birthday: contents[1].value as string,
         gender: contents[2].value === '남' ? 'MALE' : 'FEMALE',
         type: contents[3].value === '부모' ? 'parent' : 'child',
-      };
-      await signup(info)
-        .then((res) => console.log(res.data))
-        .catch((err) => console.log(err));
+      });
     },
   });
   const birthdayHandler = (year: number, month: number, day: number) => {

--- a/ssh-web/src/pages/Signup/index.tsx
+++ b/ssh-web/src/pages/Signup/index.tsx
@@ -68,13 +68,21 @@ export const Signup = () => {
   const [handler, setHandler] = useState<IContentHandler>({
     label: '회원가입',
     handler: () => {
-      mutate({
-        code: location.state?.code,
-        nickname: contents[0].value as string,
-        birthday: contents[1].value as string,
-        gender: contents[2].value === '남' ? 'MALE' : 'FEMALE',
-        type: contents[3].value === '부모' ? 'parent' : 'child',
-      });
+      const nicknameCheck = /^(?![ㄱ-ㅎㅏ-ㅣ]+$)[가-힣A-Za-z]{2,8}$/;
+      if (
+        !(contents[0].value as string).length ||
+        !nicknameCheck.test(contents[0].value as string)
+      ) {
+        alert('닉네임은 한글/영문 2~8자 입니다.');
+      } else {
+        mutate({
+          code: location.state?.code,
+          nickname: contents[0].value as string,
+          birthday: contents[1].value as string,
+          gender: contents[2].value === '남' ? 'M' : 'F',
+          type: contents[3].value === '부모' ? 'PARENT' : 'CHILD',
+        });
+      }
     },
   });
   const birthdayHandler = (year: number, month: number, day: number) => {

--- a/ssh-web/src/pages/Signup/index.tsx
+++ b/ssh-web/src/pages/Signup/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '../../interfaces/userInterface';
 import dayjs from 'dayjs';
 import { BirthdayForm } from '../../components/organisms/BirthdayForm';
-import { signup } from '../../apis/userApi';
+import { nicknameDuplicate, signup } from '../../apis/userApi';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 
@@ -67,20 +67,26 @@ export const Signup = () => {
   );
   const [handler, setHandler] = useState<IContentHandler>({
     label: '회원가입',
-    handler: () => {
+    handler: async () => {
       const nicknameCheck = /^(?![ㄱ-ㅎㅏ-ㅣ]+$)[가-힣A-Za-z]{2,8}$/;
       if (
         !(contents[0].value as string).length ||
         !nicknameCheck.test(contents[0].value as string)
       ) {
-        alert('닉네임은 한글/영문 2~8자 입니다.');
+        alert('닉네임은 한글/영문 2~8자 입니다');
       } else {
-        mutate({
-          code: location.state?.code,
-          nickname: contents[0].value as string,
-          birthday: contents[1].value as string,
-          gender: contents[2].value === '남' ? 'M' : 'F',
-          type: contents[3].value === '부모' ? 'PARENT' : 'CHILD',
+        await nicknameDuplicate(contents[0].value as string).then((res) => {
+          if (res.data.isDuplicated) {
+            mutate({
+              code: location.state?.code,
+              nickname: contents[0].value as string,
+              birthday: contents[1].value as string,
+              gender: contents[2].value === '남' ? 'M' : 'F',
+              type: contents[3].value === '부모' ? 'PARENT' : 'CHILD',
+            });
+          } else {
+            alert('중복된 닉네임입니다');
+          }
         });
       }
     },

--- a/ssh-web/src/utils/router.tsx
+++ b/ssh-web/src/utils/router.tsx
@@ -10,6 +10,7 @@ import { QuizSolving } from '../pages/QuizSolving';
 import { Mission } from '../pages/Mission';
 import { Information } from '../pages/Information';
 import { Manage } from '../pages/Information/Manage';
+import { Request } from '../pages/Information/Request';
 
 export const PathNames: IPathNames = {
   HOME: {
@@ -76,6 +77,10 @@ export const router = createBrowserRouter([
       {
         path: '/manage',
         element: <Manage />,
+      },
+      {
+        path: '/request',
+        element: <Request />,
       },
     ],
   },

--- a/ssh-web/src/utils/userUtil.ts
+++ b/ssh-web/src/utils/userUtil.ts
@@ -1,0 +1,12 @@
+export const getImgSrc = (gender: string, type: string) => {
+  const baseSrc =
+    'https://solsolhighasset.s3.ap-northease-2.amazonaws.com/images/models/';
+
+  if (gender === 'M') {
+    if (type === 'PARENT') return baseSrc + 'man1.png';
+    else return baseSrc + 'woman1.png';
+  } else {
+    if (type === 'PARENT') return baseSrc + 'boy1.png';
+    else return baseSrc + 'girl1.png';
+  }
+};

--- a/ssh-web/src/utils/userUtil.ts
+++ b/ssh-web/src/utils/userUtil.ts
@@ -1,6 +1,6 @@
 export const getImgSrc = (gender: string, type: string) => {
   const baseSrc =
-    'https://solsolhighasset.s3.ap-northease-2.amazonaws.com/images/models/';
+    'https://solsolhighasset.s3.ap-northeast-2.amazonaws.com/images/models/';
 
   if (gender === 'M') {
     if (type === 'PARENT') return baseSrc + 'man1.png';

--- a/ssh-web/src/utils/userUtil.ts
+++ b/ssh-web/src/utils/userUtil.ts
@@ -2,11 +2,11 @@ export const getImgSrc = (gender: string, type: string) => {
   const baseSrc =
     'https://solsolhighasset.s3.ap-northeast-2.amazonaws.com/images/models/';
 
-  if (gender === 'M') {
+  if (gender === 'MALE') {
     if (type === 'PARENT') return baseSrc + 'man1.png';
-    else return baseSrc + 'woman1.png';
+    else return baseSrc + 'boy1.png';
   } else {
-    if (type === 'PARENT') return baseSrc + 'boy1.png';
+    if (type === 'PARENT') return baseSrc + 'woman1.png';
     else return baseSrc + 'girl1.png';
   }
 };


### PR DESCRIPTION
## 🥥 Contents

**로그인 / 회원가입**
- 소셜로그인을 선택하였기에 백에서 제공하는 url 로 사용자를 보내주면 된다.
- 로그인이 성공적으로 수행되고 서비스에 처음 접근한 사용자라면 회원가입 페이지로 이동하게 된다.
- 회원가입에서 사용자가 닉네임을 입력할 때에는 서비스에서 요구하는 형식을 맞춰야만 하도록 검사를 수행한다.
- 모든 정보가 유효하면 정보를 종합하여 서비스의 사용자로 등록된다.

**사용자 정보 조회**
- 사용자들은 본인의 정보를 확인할 때에 역할에 맞는 정보들까지도 조회할 수 있다.
- 만약 부모라면 등록된 자녀를, 자녀라면 등록된 부모를 확인할 수 있다.
- 사용자의 성별, 역할에 따라 보여지게 되는 이미지를 달리 하였다.

**가족 정보 관리**
- 부모역할의 사용자들은 본인의 자녀들을 관리할 수 있는 페이지로 접근이 가능하다.
- 해당 페이지에서 본인의 자녀들, 그리고 등록 신청 대기 중인 자녀들까지도 볼 수 있다.
- 자녀들은 본인에게 연결된 부모, 연결 대기 중인 부모를 확인할 수 있다.

**자녀 연결 신청**
- 부모는 닉네임으로 자녀를 검색하고, 자녀를 본인과 연결시키도록 신청할 수 있다.

<!--
-   작업한 사항들에 대한 상세 설명
-   필요할 경우 관련 코드 기입
-->

## 📸 Screenshot

**로그인/회원가입**
![화면 기록 2024-08-28 오전 2 04 03](https://github.com/user-attachments/assets/a4f06e0a-f44e-42a8-b2d7-9bd12d2d1841)
<br>
![스크린샷 2024-08-28 오전 2 04 21](https://github.com/user-attachments/assets/294e3efc-4cd4-4ec4-91b0-0476b6e8f099)
<br>

**회원정보 조회 && 자녀 초대**
![화면 기록 2024-08-28 오전 2 03 05](https://github.com/user-attachments/assets/ea948af9-c27e-4ccd-a903-9da3ec75974d)<br>

<!--
-   구현된 기능들 촬영
-   필수 사항 x
-->

## ⚓ Related Issue

- #50 

<!-- close #50 -->
<!--
-   PR 에 관련된 이슈들 등록
-   #이슈번호
-   만약 해당 이슈들을 닫을 수 있다면 -> close #이슈번호
-->

## 📚 Reference

<!--
-   PR 작업 중 참고한 자료, 문서들 기입
-->
